### PR TITLE
refactor(lexer): replace String.char_at with get_char; bump MoonYacc dependency

### DIFF
--- a/moon.mod.json
+++ b/moon.mod.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "deps": {},
   "bin-deps": {
-    "moonbitlang/yacc": "0.3.45"
+    "moonbitlang/yacc": "0.7.2"
   },
   "readme": "README.md",
   "repository": "",

--- a/src/lib/lexer/lexer.mbt
+++ b/src/lib/lexer/lexer.mbt
@@ -4,13 +4,13 @@ priv suberror EndOfInput
 ///|
 pub fn tokenize(
   input : String
-) -> Array[(@parser.Token, @parser.Position, @parser.Position)] {
-  let tokens : Array[(@parser.Token, @parser.Position, @parser.Position)] = []
+) -> Array[(@parser.Token, Int, Int)] {
+  let tokens : Array[(@parser.Token, Int, Int)] = []
   let end = input.length()
   let mut cursor = 0
   fn peek_char() raise {
     guard cursor < end else { raise EndOfInput }
-    input.char_at(cursor)
+    input.get_char(cursor).unwrap()
   }
 
   fn advance() {
@@ -33,7 +33,7 @@ pub fn tokenize(
     @strconv.parse_int(buf.to_string())
   }
 
-  fn read_token() -> (@parser.Token, @parser.Position, @parser.Position) raise {
+  fn read_token() -> (@parser.Token, Int, Int) raise {
     let start = cursor
     match peek_char() {
       '0'..='9' as c => {

--- a/src/lib/parser/parser_test.mbt
+++ b/src/lib/parser/parser_test.mbt
@@ -1,7 +1,7 @@
 ///|
 test "parser" {
   // let tokens = @lexer.tokenize("3 + (2 - 5) * 0")
-  let tokens : Array[(@parser.Token, @parser.Position, @parser.Position)] = [
+  let tokens : Array[(@parser.Token, Int, Int)] = [
     (NUMBER(3), 0, 1),
     (PLUS, 1, 2),
     (LPAREN, 2, 3),


### PR DESCRIPTION
- Replace `char_at` with `input.get_char(cursor).unwrap()` to align with the current String API.
- Change `tokenize` return type from `Array[(Token, Position, Position)]` to `Array[(Token, Int, Int)]`.
- Update tests to match the new signature.
- Bump `moonbitlang/yacc` to `0.7.2`.

Rationale:
- On my setup, `@parser.Position` could not be resolved. I’m not sure whether this is due to a missing import, package configuration, or an API change. As a temporary measure, I switched the position type to `Int` to keep the project compiling. Please advise on the intended `Position` type and the correct way to reference it; I’m happy to adjust this PR accordingly.
